### PR TITLE
Allow content editor to publish lesson plans with minimal information

### DIFF
--- a/components/contentThumbnailList.js
+++ b/components/contentThumbnailList.js
@@ -11,7 +11,7 @@ export default ({ items }) =>
 				padding-top: 1rem;
 				padding-bottom: 1rem;
 				max-width: calc(70rem);
-				justify-items: center;
+				justify-items: stretch;
 			}
 			@media screen and (max-width: 70rem) {
 				.root {

--- a/components/pages/lessonPlan.js
+++ b/components/pages/lessonPlan.js
@@ -416,7 +416,7 @@ export default ({
 				</div>
 			</div>
 		}
-		<div className='section pdf color'>
+		{/* <div className='section pdf color'>
 			<div className='wrapper'>
 				<h3 className='heading'>{appProps.strings.printFriendly}</h3>
 				<Button
@@ -426,6 +426,7 @@ export default ({
 				/>
 			</div>
 		</div>
+		*/}
 		{relatedContent && (relatedContent.length > 0) &&
 			<div className='section relatedContent not-color'>
 				<div className='wrapper'>

--- a/utils/computeContentInitialInfoProps.js
+++ b/utils/computeContentInitialInfoProps.js
@@ -1,13 +1,13 @@
 export default (props, appProps) => ({
 	initialInfo : {
-		duration       : props.duration.title,
-		durationLabel  : appProps.strings.duration,
-		groupSize      : props.groupSize.title,
-		groupSizeLabel : appProps.strings.groupSize,
-		classSize      : props.classSize.title,
-		classSizeLabel : appProps.strings.classSize,
-		overview       : props.overview,
-		overviewLabel  : appProps.strings.overview,
-		gallery        : props.gallery
+		duration       : props && props.duration && props.duration.title,
+		durationLabel  : appProps && appProps.strings && appProps.strings.duration,
+		groupSize      : props && props.groupSize && props.groupSize.title,
+		groupSizeLabel : appProps && appProps.strings && appProps.strings.groupSize,
+		classSize      : props && props.classSize && props.classSize.title,
+		classSizeLabel : appProps && appProps.strings && appProps.strings.classSize,
+		overview       : props && props.overview,
+		overviewLabel  : appProps && appProps.strings && appProps.strings.overview,
+		gallery        : props && props.gallery
 	}
 })


### PR DESCRIPTION
There was still some errors being thrown in case information was missing in the lesson plans. Found the errors and added a branching that allows for them. 

Now lessons plans can be published with as little as a title.